### PR TITLE
Time to Open

### DIFF
--- a/lib/learn_open/opener.rb
+++ b/lib/learn_open/opener.rb
@@ -270,7 +270,7 @@ module LearnOpen
       if ios_lesson?
         open_ios_lesson
       elsif editor
-        system("cd #{lessons_dir}/#{repo_dir} && #{editor} .")
+        system("#{editor} .")
       end
     end
 

--- a/lib/learn_open/opener.rb
+++ b/lib/learn_open/opener.rb
@@ -343,7 +343,7 @@ module LearnOpen
     def bundle_install
       if !ios_lesson? && File.exists?("#{lessons_dir}/#{repo_dir}/Gemfile")
         puts "Bundling..."
-        system("cd #{lessons_dir}/#{repo_dir} && bundle install > /dev/null 2>&1")
+        system("bundle install > /dev/null 2>&1")
       end
     end
 
@@ -352,9 +352,9 @@ module LearnOpen
         puts 'Installing dependencies...'
 
         if ide_environment?
-          system("cd #{lessons_dir}/#{repo_dir} && yarn install --no-lockfile")
+          system("yarn install --no-lockfile")
         else
-          system("cd #{lessons_dir}/#{repo_dir} && npm install")
+          system("npm install")
         end
       end
     end

--- a/lib/learn_open/opener.rb
+++ b/lib/learn_open/opener.rb
@@ -31,10 +31,10 @@ module LearnOpen
       else
         fork_repo
         clone_repo
+        cd_to_lesson
+        open_with_editor
         bundle_install
         npm_install
-        open_with_editor
-        cd_to_lesson
       end
     end
 

--- a/lib/learn_open/opener.rb
+++ b/lib/learn_open/opener.rb
@@ -29,12 +29,10 @@ module LearnOpen
       if lesson_is_readme?
         open_readme
       else
-        fork_repo
-        clone_repo
-        cd_to_lesson
-        open_with_editor
-        bundle_install
-        npm_install
+        git_tasks
+        file_tasks
+        dependency_tasks
+        completion_tasks
       end
     end
 
@@ -335,9 +333,6 @@ module LearnOpen
     def cd_to_lesson
       puts "Opening lesson..."
       Dir.chdir("#{lessons_dir}/#{repo_dir}")
-      cleanup_tmp_file
-      puts "Done."
-      exec("#{ENV['SHELL']} -l")
     end
 
     def bundle_install
@@ -403,6 +398,27 @@ module LearnOpen
 
     def ide_environment?
       ENV['IDE_CONTAINER'] == "true"
+    end
+
+    def git_tasks
+      fork_repo
+      clone_repo
+    end
+
+    def file_tasks
+      cd_to_lesson
+      open_with_editor
+    end
+
+    def dependency_tasks
+      bundle_install
+      npm_install
+    end
+
+    def completion_tasks
+      cleanup_tmp_file
+      puts "Done."
+      exec("#{ENV['SHELL']} -l")
     end
   end
 end


### PR DESCRIPTION
Hello Awesome Flatiron Folks,

To dive right into it, the main goal of this PR is to modify the order in which this gem opens students' lessons after calling `learn open <repo-name>` or simply `learn open`.  After forking and cloning, these modifications will `cd` into the correct directory and open the lesson in the preferred text editor.  Then the gem will go about installing dependencies and handling the completion of this process.

The "why" behind this modification is due to an experience I had with using the gem this weekend.  It's been awhile since I have delved into the content since graduating and I am finally getting through the  React & Redux sections.  So this weekend I type `learn open` to go ahead and get the 🎉  started and then I sit there and wait.  And wait. And wait.  

On average I wait around 3 minutes before the text editor opens up with my lesson code inside it.  During these 3 minutes I usually decide to read through the lesson, but most of the lessons I can read for about 30 seconds before I hit the first code sample.  Then I'm sitting there watching the `npm install` finish installing over 1100 dependencies and waiting.  I am usually patient enough to wait for this to finish, BUT sometimes I lose focus.  I switch tasks and watch a youtube video or read an article, etc.  And really 3 minutes is not a super long time in the grand scheme of things, especially when considering the culture of JS dependencies, but if you add it up over all the lessons in the Full Stack program, it's about 1.5 years (dog years 😉 ) give or take.  

To me, this seems like a bit of a UX issue that can be improved.  The commits in this PR consist of a couple things:

1. The tasks in the `opener#run` command were reordered so that it will `cd` into the lesson directory and then open the preferred text editor.
2. After this change, I noticed that both the `bundle_install` and `npm_install` moved into the repo and ran the commands.  Since it should already be inside the correct dir, I removed that portion of the system command (`cd #{lessons_dir}/#{repo_dir} && `).
3. I noticed that inside the `cd_to_lesson` method were some completion type tasks.  Cleanup, `puts "Done"` etc.  So I extracted those out into their own method and added it to the end of the `run` method.
4. When doing #3, I realized that the prior tasks in the `run` method all had sort of a focus.  There were git commands (fork and clone), file util tasks (cd and open in editor), and dependency tasks.  So I went ahead and extracted those out into their own respective methods.

To try the new flow out yourself, first clone down my branch of this.

`git clone -b order-of-opening git@github.com:zacscodingclub/learn-open.git`

Then move into that repo and do a `bundle install`.

Once inside there, you can execute the gem by calling ` learn-open create-store-lab-v-000` in your terminal.  You'll notice it forks, clones, opens the text editor, then does the dependency installation while you're able to access the lesson in your text editor.  

It's a small improvement, but it seems to help ability to stay on task and :learn:.  I'd love any feedback about this and feel free to cherry-pick anything as needed.  

CC: @aturkewi 