### PR TITLE
In IDE context, run backup lab when files are deleted

### DIFF
--- a/lib/learn_open/opener.rb
+++ b/lib/learn_open/opener.rb
@@ -443,7 +443,7 @@ module LearnOpen
     end
 
     def watch_for_changes
-      Process.spawn("while inotifywait -re create,delete,move,close_write #{lessons_dir}/#{repo_dir}; do backup-lab; done", [:out, :err] => File::NULL)
+      Process.spawn("while inotifywait -qre create,delete,move,close_write #{lessons_dir}/#{repo_dir}; do backup-lab; done", [:out, :err] => File::NULL)
     end
 
     def completion_tasks

--- a/lib/learn_open/opener.rb
+++ b/lib/learn_open/opener.rb
@@ -443,7 +443,7 @@ module LearnOpen
     end
 
     def watch_for_changes
-      Process.spawn("while inotifywait -e close_write,create,moved_to -r #{lessons_dir}/#{repo_dir}; do backup-lab; done", [:out, :err] => File::NULL)
+      Process.spawn("while inotifywait -re create,delete,move,close_write #{lessons_dir}/#{repo_dir}; do backup-lab; done", [:out, :err] => File::NULL)
     end
 
     def completion_tasks


### PR DESCRIPTION
**Update 5/25/18**: Not a crazy bug (especially considering that it's survived for so long), but we aren't running the backup when deletes happen. Also, we aren't running it recursively? Which seems like it would have created much larger problems... but it hasn't really... so I'm not sure what to make of that 🤔 