### PR TITLE
restrict lesson warning

### DIFF
--- a/lib/learn_open/opener.rb
+++ b/lib/learn_open/opener.rb
@@ -35,14 +35,15 @@ module LearnOpen
       end
 
       puts "Looking for lesson..."
-      warn_if_necessary
 
       if jupyter_notebook_environment?
         git_tasks
         file_tasks
-        setup_backup_if_needed
+        restore_files
+        watch_for_changes
         completion_tasks
       else
+        warn_if_necessary
         if lesson_is_readme?
           open_readme
         else
@@ -63,7 +64,7 @@ module LearnOpen
     private
 
     def setup_backup_if_needed
-      if ide_environment? && ide_git_wip_enabled? || jupyter_notebook_environment?
+      if ide_environment? && ide_git_wip_enabled?
         restore_files
         watch_for_changes
       end

--- a/lib/learn_open/version.rb
+++ b/lib/learn_open/version.rb
@@ -1,3 +1,3 @@
 module LearnOpen
-  VERSION = '1.2.17'
+  VERSION = '1.2.18'
 end


### PR DESCRIPTION
This change allows students accessing content from within a Jupyter container from being warned if they're trying to access a lesson beyond their current lesson.