### PR TITLE
inotifywait excludes .git and node_modules

### DIFF
--- a/lib/learn_open/adapters/system_adapter.rb
+++ b/lib/learn_open/adapters/system_adapter.rb
@@ -12,7 +12,7 @@ module LearnOpen
       end
 
       def self.watch_dir(dir, action)
-        spawn("while inotifywait -qre create,delete,move,close_write #{dir}; do #{action}; done")
+        spawn("while inotifywait -qre create,delete,move,close_write --exclude \"#{excluded_dirs}\" #{dir}; do #{action}; done")
       end
 
       def self.spawn(command, block: false)
@@ -30,6 +30,12 @@ module LearnOpen
 
       def self.change_context_directory(dir)
         Dir.chdir(dir)
+      end
+
+      private
+
+      def self.excluded_dirs
+        "(node_modules/|\.git/|\.swp?x?$|~$|4913$)"
       end
     end
   end

--- a/lib/learn_open/version.rb
+++ b/lib/learn_open/version.rb
@@ -1,3 +1,3 @@
 module LearnOpen
-  VERSION = '1.2.24'
+  VERSION = '1.2.25'
 end


### PR DESCRIPTION
This `inotifywait` process was not excluding `.git` and `node_modules`. 