### PR TITLE
Prevent a crash if no iOS languages in dot_learn

### DIFF
--- a/lib/learn_open/lessons/ios_lesson.rb
+++ b/lib/learn_open/lessons/ios_lesson.rb
@@ -3,7 +3,7 @@ module LearnOpen
     class IosLesson < BaseLesson
       def self.detect(lesson)
         languages = Hash(lesson.dot_learn)[:languages]
-        (languages & ["swift", "objc"]).any?
+        !!languages && (languages & ["swift", "objc"]).any?
       end
 
       def open(environment, editor, clone_only)


### PR DESCRIPTION
The existing code crashes if lesson.dot_learn is empty, or otherwise does not contain a :languages key.  This checks whether the languages exist before checking if they contain "swift" or "objc".
Closes #23 (and #30)
#staff