### PR TITLE
Default to empty array for dotlearn languages

### DIFF
--- a/learn-open.gemspec
+++ b/learn-open.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib", "bin"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake",    "~> 10.0"
   spec.add_development_dependency "fakefs",  "~> 0.14.2"
   spec.add_development_dependency "pry",     "~> 0.11.1"

--- a/lib/learn_open/lessons/ios_lesson.rb
+++ b/lib/learn_open/lessons/ios_lesson.rb
@@ -3,7 +3,7 @@ module LearnOpen
     class IosLesson < BaseLesson
       def self.detect(lesson)
         languages = Hash(lesson.dot_learn)[:languages]
-        (languages & ["swift", "objc"]).any?
+        !!languages && (languages & ["swift", "objc"]).any?
       end
 
       def open(environment, editor, clone_only)

--- a/lib/learn_open/lessons/ios_lesson.rb
+++ b/lib/learn_open/lessons/ios_lesson.rb
@@ -2,8 +2,8 @@ module LearnOpen
   module Lessons
     class IosLesson < BaseLesson
       def self.detect(lesson)
-        languages = Hash(lesson.dot_learn)[:languages]
-        !!languages && (languages & ["swift", "objc"]).any?
+        languages = Hash(lesson.dot_learn).fetch(:languages, [])
+        (languages & ["swift", "objc"]).any?
       end
 
       def open(environment, editor, clone_only)

--- a/spec/learn_open/lessons/ios_lesson_spec.rb
+++ b/spec/learn_open/lessons/ios_lesson_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe LearnOpen::Lessons::IosLesson do
+  context ".detect" do
+    subject do
+      LearnOpen::Lessons::IosLesson
+    end
+    it "classifies if in the dot learn file" do
+      swift_lesson = OpenStruct.new(dot_learn: {languages: ["objc"]})
+      objc_lesson = OpenStruct.new(dot_learn: {languages: ["swift"]})
+      expect(subject.detect(swift_lesson)).to be_truthy
+      expect(subject.detect(objc_lesson)).to be_truthy
+    end
+
+    it "doesn't classify ruby labs" do
+      ruby_lesson = OpenStruct.new(dot_learn: {languages: ["ruby"]})
+      expect(subject.detect(ruby_lesson)).to be_falsey
+    end
+
+    it "handles dot learn with no languages key" do
+      no_languages = OpenStruct.new(dot_learn: {})
+      expect(subject.detect(no_languages)).to be_falsy
+    end
+
+    it "handles missing dot_learn file" do
+      no_dot_learn_file = OpenStruct.new(nada: false)
+      expect(subject.detect(no_dot_learn_file)).to be_falsy
+    end
+  end
+end

--- a/spec/learn_open/opener_spec.rb
+++ b/spec/learn_open/opener_spec.rb
@@ -243,7 +243,6 @@ describe LearnOpen::Opener do
       allow(system_adapter).to receive_messages(
         open_editor: :noop,
         spawn: :noop,
-        spawn: :noop,
         open_login_shell: :noop,
         change_context_directory: :noop,
         run_command: :noop,
@@ -272,7 +271,6 @@ Failed to obtain an SSH connection!
 
       allow(system_adapter).to receive_messages(
         open_editor: :noop,
-        spawn: :noop,
         spawn: :noop,
         open_login_shell: :noop,
         change_context_directory: :noop,
@@ -306,7 +304,6 @@ Done.
 
       allow(system_adapter).to receive_messages(
         open_editor: :noop,
-        spawn: :noop,
         spawn: :noop,
         open_login_shell: :noop,
         change_context_directory: :noop,


### PR DESCRIPTION
This pull request combines the commits from #35, where the fix was first proposed by @hoffm386, and #38 where @StevenNunez added the necessary test coverage to document the bug.

The previous code assumed that a `languages` key would always be present in the dotlearn, and would fail whenever that turned out not to be the case. The change here now defaults to an empty array if no `languages` key is found.

Closes #23 
Closes #30 
Closes [EDM-522](https://flatiron.atlassian.net/browse/EDM-522)