### PR TITLE
Reveal git error messages on clone/fork fail, enforce Github username

### DIFF
--- a/lib/learn_open/lessons/base_lesson.rb
+++ b/lib/learn_open/lessons/base_lesson.rb
@@ -22,7 +22,7 @@ module LearnOpen
 
         @repo_path = lesson.clone_repo
         @organization, @name = repo_path.split('/')
-        if @organization.empty?
+        if @organization.empty? and not @name.empty?
           raise "The repo path had an empty organization. Most likely, you need to link your Github account to your Learn account through the Learn website."
         end
 

--- a/lib/learn_open/lessons/base_lesson.rb
+++ b/lib/learn_open/lessons/base_lesson.rb
@@ -22,6 +22,9 @@ module LearnOpen
 
         @repo_path = lesson.clone_repo
         @organization, @name = repo_path.split('/')
+        if @organization.empty?
+          raise "The repo path had an empty organization. Most likely, you need to link your Github account to your Learn account through the Learn website."
+        end
 
         @git_server = lesson.git_server
         @dot_learn = lesson.dot_learn

--- a/lib/learn_open/services/lesson_downloader.rb
+++ b/lib/learn_open/services/lesson_downloader.rb
@@ -43,9 +43,11 @@ module LearnOpen
         Timeout::timeout(15) do
           client.fork_repo(repo_name: lesson.name)
         end
-      rescue Timeout::Error
+      rescue Timeout::Error => e
         if retries > 0
           io.puts "There was a problem forking this lesson. Retrying..."
+          io.puts "Git had the following error:"
+          io.puts e
           fork_repo(retries - 1)
         else
           io.puts "There is an issue connecting to Learn. Please try again."
@@ -63,9 +65,11 @@ module LearnOpen
         Timeout::timeout(15) do
           git_adapter.clone("git@#{lesson.git_server}:#{lesson.repo_path}.git", lesson.name, path: location)
         end
-      rescue Git::GitExecuteError
+      rescue Git::GitExecuteError => e
         if retries > 0
           io.puts "There was a problem cloning this lesson. Retrying..." if retries > 1
+          io.puts "Git had the following error:"
+          io.puts e
           sleep(1)
           clone_repo(retries - 1)
         else
@@ -75,7 +79,7 @@ module LearnOpen
         end
       rescue Timeout::Error
         if retries > 0
-          io.puts "There was a problem cloning this lesson. Retrying..."
+          io.puts "There was a problem cloning this lesson (timed out). Retrying..."
           clone_repo(retries - 1)
         else
           io.puts "Cannot clone this lesson right now. Please try again."


### PR DESCRIPTION
Hi all, I'm teaching a coding bootcamp for [Re:Coded](https://www.re-coded.com/) that uses learn.co. Some students are getting tripped up by obscure error messages about being unable to clone, and it's hard for us to diagnose the issue based on the current error message

This pull requests does two things:
1. When there is a Git error in cloning/forking, it prints out the error to the console (not to the logger) so that students can show it to instructors.
2. In initializing the lesson, it enforces that `@organization` can be parsed and is non-empty as a result. If it is empty, it suggests that the user link a Github account (perhaps there's a better place to do this, the maintainer can decide)

Note that there is an additional bug that's not being addressed, which is that the "forking logic" passes successfully even when there is no Github account, but despite nothing actually being forked. For this, I've filed #40 

(The root issue is the setup documentation: none of the Mac, Linux, or Windows instructions say that linking your Github account is required, e.g., this link does not say you *must* link your Github account. https://github.com/learn-co-curriculum/wsl-setup)